### PR TITLE
Remove systems and flake-parts dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,24 +36,6 @@
         "type": "github"
       }
     },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1756125398,
@@ -70,29 +52,12 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1753579242,
-        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "crane": "crane",
         "fenix": "fenix",
-        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "rust-manifest": "rust-manifest",
-        "systems": "systems",
         "typst": "typst"
       }
     },
@@ -123,21 +88,6 @@
       "original": {
         "type": "file",
         "url": "https://static.rust-lang.org/dist/channel-rust-1.91.0.toml"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     },
     "typst": {


### PR DESCRIPTION
As a minimalist, and after seeing how "convenient" inputs can only complicate the config, rather than simplify it, I don't like that there are `flake-parts` and `systems`.

In short, it creates unnecessary dependencies, which in turn
- makes the config be written in a certain, more restrictive way
  - makes it harder to read, force people to learn/use yet another level of abstraction on top of flakes
- less portable between native-flake-schema-based configs
- any potential issues with dependencies, you have to depend on the upstream to solve them
- 3 more small or big blobs to download in `flake.lock`, slowing down the initial download, and increasing Internet traffic for little to no benefit

First time I discovered this from @partywumpus [here](https://discord.com/channels/1054443721975922748/1080791870982078504/1347347203903066122), and that [flake config can be shorter without `flake-utils`](https://discord.com/channels/1054443721975922748/1080791870982078504/1347348802142601266).

Since then, I wrote several flakes without any of those `systems`/`flake-parts`/`flake-utils` nonsense, and also rewrote some other ones (like ejecting from `devenv`, that is also restrictive). This made my flakes minimal and more accessible to be copied partly or fully by others, without using any new tech someone doesn't like/know about.

---

I didn't reformat everything yet, only the new part.

As you can see, it produces 34 - 62 = -28 lines total, plus removing the overhead of downloading, extracting and evaluating 3 dependencies.

This shows that it works the exact same way, transparently substituting one wrapper with another, while all the other lines stay untouched. After reformat, it won't look the same.

The unfortunate part is that I don't know if there is a more straightforward ways to transform `system.name.value` to `name.system.value`. Using `nixpkgs.lib` will produce the same amount of code, but part of it will be `inherit`ing a bunch of pre-made functions, instead of using a more native way without any lib stuff.