### PR TITLE
Remove systems and flake-parts dependencies (simpler alternative)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,24 +36,6 @@
         "type": "github"
       }
     },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1756125398,
@@ -70,29 +52,12 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1753579242,
-        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "crane": "crane",
         "fenix": "fenix",
-        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "rust-manifest": "rust-manifest",
-        "systems": "systems",
         "typst": "typst"
       }
     },
@@ -123,21 +88,6 @@
       "original": {
         "type": "file",
         "url": "https://static.rust-lang.org/dist/channel-rust-1.91.0.toml"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     },
     "typst": {


### PR DESCRIPTION
Same as https://github.com/typst/typst-flake/pull/3, but reuses a different `perSystem` function that now provides all the necessary value in the inner `inputs`.

This is now 25 - 79 = -54 lines reduction, which is better on paper than #3, but also is better visually. In other words, it removes the overcomplicated `perSystem` shenanigans (the attrs transformation), and provides a more straightforward interface for setting all of the `output`'s top-level attribute fields (`formatter`, `apps`, etc.).

It also is not entirely formatted to showcase the difference between base and #3.

For now, just a thing to show.
