### PR TITLE
fix: error on target platform != x86_64-unknown-linux-gnu

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,12 +61,13 @@
 
           rust-toolchain = fenix.packages.${system}.fromManifestFile rust-manifest;
 
-          rustflags =
-            if pkgs.stdenv.hostPlatform.rust.rustcTargetSpec == "x86_64-unknown-linux-gnu" then
-              # Upstream defaults to lld on x86_64-unknown-linux-gnu, we need to use the system linker
-              "-Clinker-features=-lld -Clink-self-contained=-linker"
-            else
-              null;
+          # Upstream defaults to lld on x86_64-unknown-linux-gnu, we need to use the system linker
+          rustflags = lib.concatStringsSep " " (
+            lib.optionals (pkgs.stdenv.hostPlatform.rust.rustcTargetSpec == "x86_64-unknown-linux-gnu") [
+              "-Clinker-features=-lld"
+              "-Clink-self-contained=-linker"
+            ]
+          );
 
           # Crane-based Nix flake configuration.
           # Based on https://github.com/ipetkov/crane/blob/master/examples/trunk-workspace/flake.nix


### PR DESCRIPTION
Hey there, thanks a lot for maintaining this! Hope you don't mind me skipping the issue step.

When trying to use this flake on Darwin, I ran into the following error:

```
❯ nix run github:typst/typst-flake
error:
       … while evaluating the attribute 'value'
         at /nix/store/2f0w7jys97fs8sld7qqg1ck7h2j3asjg-source/lib/modules.nix:1118:7:
         1117|     // {
         1118|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1119|       inherit (res.defsFinal') highestPrio;

       … while calling the 'addErrorContext' builtin
         at /nix/store/2f0w7jys97fs8sld7qqg1ck7h2j3asjg-source/lib/modules.nix:1118:15:
         1117|     // {
         1118|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |               ^
         1119|       inherit (res.defsFinal') highestPrio;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `RUSTFLAGS` attribute is of type null.
```

This is due the fact that `RUSTFLAGS` is set to `null`, when target != `x86_64-unknown-linux-gnu` [see here](https://github.com/typst/typst-flake/blob/0862b4b4c562fdc245063519b012507951a53181/flake.nix#L64C11-L69C20)

```nix
rustflags =
            if pkgs.stdenv.hostPlatform.rust.rustcTargetSpec == "x86_64-unknown-linux-gnu" then
              # Upstream defaults to lld on x86_64-unknown-linux-gnu, we need to use the system linker
              "-Clinker-features=-lld -Clink-self-contained=-linker"
            else
              null;
```

[Relevant check in `nixpkgs`](https://github.com/NixOS/nixpkgs/blob/14fc170c3962a2b5ca31b5c6fad98dff6f1e9548/pkgs/stdenv/generic/make-derivation.nix#L852)

```nix
        mapAttrs (
          n: v:
          assert assertMsg (isString v || isBool v || isInt v || isDerivation v)
            "The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `${n}` attribute is of type ${builtins.typeOf v}.";
          v
        ) env';
```

Minor note: as per https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags an empty `RUSTFLAGS` still overrides user configuration (e.g. in cargo config); see [this](https://github.com/NixOS/nixpkgs/commit/978d298b4b94024b15bf2ab79c65495b03076346)